### PR TITLE
refactor: Use environment variable for API URL

### DIFF
--- a/client/.env.example
+++ b/client/.env.example
@@ -1,0 +1,4 @@
+# This is the base URL for your backend API.
+# For local development, it would be http://localhost:5000
+# For production, it would be your deployed Render URL.
+NEXT_PUBLIC_API_URL=https://resumemaker-58xv.onrender.com

--- a/client/app/page.tsx
+++ b/client/app/page.tsx
@@ -27,7 +27,8 @@ export default function Home() {
       const formData = new FormData();
       formData.append('cv', file);
 
-      const response = await fetch('http://localhost:5000/api/cv/upload', {
+      const apiUrl = process.env.NEXT_PUBLIC_API_URL || 'http://localhost:5000';
+      const response = await fetch(`${apiUrl}/api/cv/upload`, {
         method: 'POST',
         body: formData,
       });
@@ -74,7 +75,8 @@ export default function Home() {
     setIsLoading(true);
     setError(null);
     try {
-      const response = await fetch(`http://localhost:5000/api/cv/${id}`);
+      const apiUrl = process.env.NEXT_PUBLIC_API_URL || 'http://localhost:5000';
+      const response = await fetch(`${apiUrl}/api/cv/${id}`);
       if (!response.ok) {
         throw new Error('Failed to fetch CV data.');
       }

--- a/client/components/ExportCV.tsx
+++ b/client/components/ExportCV.tsx
@@ -32,9 +32,10 @@ export default function ExportCV({ cvId, cvData, onClose }: ExportCVProps) {
         return;
       }
 
+      const apiUrl = process.env.NEXT_PUBLIC_API_URL || 'http://localhost:5000';
       const endpoint = type === 'docx'
-        ? `http://localhost:5000/api/cv/${cvId}/export-docx`
-        : `http://localhost:5000/api/cv/${cvId}/export`;
+        ? `${apiUrl}/api/cv/${cvId}/export-docx`
+        : `${apiUrl}/api/cv/${cvId}/export`;
 
       const response = await fetch(endpoint);
 

--- a/client/components/SavedCVs.tsx
+++ b/client/components/SavedCVs.tsx
@@ -22,7 +22,8 @@ export default function SavedCVs({ onViewCV }: SavedCVsProps) {
   useEffect(() => {
     const fetchSavedCVs = async () => {
       try {
-        const response = await fetch('http://localhost:5000/api/cv/all');
+        const apiUrl = process.env.NEXT_PUBLIC_API_URL || 'http://localhost:5000';
+        const response = await fetch(`${apiUrl}/api/cv/all`);
         if (!response.ok) {
           throw new Error('Failed to fetch saved CVs');
         }


### PR DESCRIPTION
Replaced all hardcoded instances of the backend API URL (`http://localhost:5000`) with a Next.js environment variable (`NEXT_PUBLIC_API_URL`).

This change makes the application more flexible and allows for easy configuration for different environments (local, staging, production).

- Added `client/.env.local` for local development.
- Added `client/.env.example` to document the new variable.
- Updated `page.tsx`, `ExportCV.tsx`, and `SavedCVs.tsx` to use `process.env.NEXT_PUBLIC_API_URL`.