### PR TITLE
fix(client): Ensure type safety in CVEditor update function

### DIFF
--- a/client/components/CVEditor.tsx
+++ b/client/components/CVEditor.tsx
@@ -17,13 +17,17 @@ interface CVEditorProps {
 export default function CVEditor({ cvData, onUpdateCV }: CVEditorProps) {
   const [editData, setEditData] = useState<CVData>(cvData);
 
-  const updateField = (section: keyof CVData, field: string, value: any) => {
+  const updateField = <S extends 'header' | 'personalDetails'>(
+    section: S,
+    field: keyof CVData[S],
+    value: any
+  ) => {
     setEditData(prev => ({
       ...prev,
       [section]: {
         ...prev[section],
-        [field]: value
-      }
+        [field]: value,
+      },
     }));
   };
 


### PR DESCRIPTION
This commit resolves a TypeScript error in the `CVEditor.tsx` component that was causing the Netlify build to fail.

The error "Spread types may only be created from object types" occurred because the generic `updateField` function was not type-safe. Its `section` parameter was too broad, allowing keys for non-object properties of the CVData type.

The fix refactors the `updateField` function to use TypeScript generics, constraining the `section` parameter to only `'header' | 'personalDetails'`. This ensures that the spread operator is only used on object types, making the function type-safe and fixing the build error.